### PR TITLE
Improve map drawer search and results presentation.

### DIFF
--- a/components/map-drawer.tsx
+++ b/components/map-drawer.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { MediaLocation } from "@/lib/airtable/types";
 import { FILTER_PARAMS, removeQueryParameter } from "@/lib/utils";
+import { matchesSearch } from "@/lib/search";
 import { Button } from "./ui/button";
 import Search from "./search";
 import { ResultCard } from "./result-card";
@@ -52,23 +53,9 @@ export function MapDrawer({
 
   // Filter results by search text
   const searchedResults = useMemo(() => {
-    if (!searchValue.trim()) return filteredMediaPoints;
-
-    const query = searchValue.toLowerCase();
-    return filteredMediaPoints.filter((media) => {
-      const searchable = [
-        media.name,
-        media.city,
-        media.country,
-        media.media?.release_year?.toString(),
-        media.region,
-        media.location_name,
-      ]
-        .filter(Boolean)
-        .join(" ")
-        .toLowerCase();
-      return searchable.includes(query);
-    });
+    return filteredMediaPoints.filter((media) =>
+      matchesSearch(media, searchValue)
+    );
   }, [searchValue, filteredMediaPoints]);
 
   function handleBack() {

--- a/components/result-card.tsx
+++ b/components/result-card.tsx
@@ -22,14 +22,16 @@ export function ResultCard({ media, isSelected }: ResultCardProps) {
       aria-label={`Select ${media.name}`}
     >
       <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0">
+        <div className="min-w-0 space-y-2">
           <p className="font-medium text-sm truncate">
             {media.name}{" "}
             {media.media?.release_year && `(${media.media.release_year})`}
           </p>
-          {media.country && (
+          {(media.country || media.media?.director) && (
             <p className="text-xs text-muted-foreground truncate">
-              {media.country}
+              {[media.country, media.media?.director]
+                .filter(Boolean)
+                .join(" · ")}
             </p>
           )}
         </div>

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,0 +1,25 @@
+import { MediaLocation } from "@/lib/airtable/types";
+
+// Utility function used to fuzzy search across media and locationfields
+export function matchesSearch(media: MediaLocation, query: string): boolean {
+  if (!query.trim()) return true;
+  const q = query.toLowerCase();
+  const searchable = [
+    media.name,
+    media.city,
+    media.country,
+    media.region,
+    media.location_name,
+    media.natural_feature_name,
+    media.media?.name,
+    media.media?.media_type,
+    media.media?.director,
+    media.media?.release_year?.toString(),
+    media.media?.subjects?.join(" "),
+    media.media?.language?.join(" "),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  return searchable.includes(q);
+}


### PR DESCRIPTION
This PR improves the map drawer search by adding more fields to be included in the fuzzy search such as directory and subjects. I extracted the search logic into a standalone util that can be used elsewhere if needed.

Lastly, I added director to the result card used to display search results in the map drawer.