### PR TITLE
Filter map markers by search text and fix selection flicker

### DIFF
--- a/components/map-container.tsx
+++ b/components/map-container.tsx
@@ -2,6 +2,7 @@
 
 import { MapFilters, MediaLocation } from "@/lib/airtable/types";
 import { cn, computeMapBounds } from "@/lib/utils";
+import { matchesSearch } from "@/lib/search";
 import { useSearchParams } from "next/navigation";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { Map } from "@/components/map";
@@ -29,6 +30,7 @@ export default function MapContainer({ mediaPoints }: MapContainerProps) {
   const [prevMediaPointId, setPrevMediaPointId] = useState(mediaPointId);
   const [drawerOpen, setDrawerOpen] = useState(true);
   const [mapStyle, setMapStyle] = useState<MapStyle>("standard");
+  const [searchValue, setSearchValue] = useState("");
   const mapInstanceRef = useRef<mapboxgl.Map | null>(null);
   const isTablet = useIsTablet();
 
@@ -100,6 +102,14 @@ export default function MapContainer({ mediaPoints }: MapContainerProps) {
     });
   }, [filters, mediaPoints]);
 
+  const searchedMediaPoints = useMemo(() => {
+    return filteredMediaPoints.filter((media) =>
+      matchesSearch(media, searchValue)
+    );
+  }, [searchValue, filteredMediaPoints]);
+
+  // Bounds are computed from filter results only (not search),
+  // so the map doesn't refit on every keystroke.
   const mapBounds = useMemo(
     () => computeMapBounds(filteredMediaPoints),
     [filteredMediaPoints]
@@ -109,15 +119,17 @@ export default function MapContainer({ mediaPoints }: MapContainerProps) {
     <div className="w-full relative h-[calc(100vh-4rem)]">
       <div className="relative w-full h-full overflow-hidden">
         <Map
-          data={filteredMediaPoints}
+          data={searchedMediaPoints}
           bounds={mapBounds}
           filters={filters}
           styleUrl={STYLES[mapStyle]}
           onMapReady={handleMapReady}
         />
         <MapDrawer
-          filteredMediaPoints={filteredMediaPoints}
+          searchedMediaPoints={searchedMediaPoints}
           allMediaPoints={mediaPoints}
+          searchValue={searchValue}
+          onSearchChange={setSearchValue}
           isOpen={drawerOpen}
           onToggle={handleDrawerToggle}
         />

--- a/components/map-drawer.tsx
+++ b/components/map-drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import { useSearchParams } from "next/navigation";
 import {
   ArrowLeft,
@@ -12,7 +12,6 @@ import {
 } from "lucide-react";
 import { MediaLocation } from "@/lib/airtable/types";
 import { FILTER_PARAMS, removeQueryParameter } from "@/lib/utils";
-import { matchesSearch } from "@/lib/search";
 import { Button } from "./ui/button";
 import Search from "./search";
 import { ResultCard } from "./result-card";
@@ -20,19 +19,22 @@ import { LocationDetails } from "./location-details";
 import { useIsTablet } from "./hooks/use-tablet";
 
 interface MapDrawerProps {
-  filteredMediaPoints: MediaLocation[];
+  searchedMediaPoints: MediaLocation[];
   allMediaPoints: MediaLocation[];
+  searchValue: string;
+  onSearchChange: (value: string) => void;
   isOpen: boolean;
   onToggle: () => void;
 }
 
 export function MapDrawer({
-  filteredMediaPoints,
+  searchedMediaPoints,
   allMediaPoints,
+  searchValue,
+  onSearchChange,
   isOpen,
   onToggle,
 }: MapDrawerProps) {
-  const [searchValue, setSearchValue] = useState("");
   const searchParams = useSearchParams();
   const mediaPointId = searchParams.get("mediaPointId");
   const isMobile = useIsTablet();
@@ -50,13 +52,6 @@ export function MapDrawer({
   const selectedMediaPoint = mediaPointId
     ? allMediaPoints.find((point) => point.id === mediaPointId)
     : null;
-
-  // Filter results by search text
-  const searchedResults = useMemo(() => {
-    return filteredMediaPoints.filter((media) =>
-      matchesSearch(media, searchValue)
-    );
-  }, [searchValue, filteredMediaPoints]);
 
   function handleBack() {
     window.history.pushState({}, "", removeQueryParameter("mediaPointId"));
@@ -129,7 +124,7 @@ export function MapDrawer({
           className="gap-1 -ml-2"
         >
           <ArrowLeft className="h-4 w-4" />
-          Back to Search
+          Back to Results
         </Button>
         <Button
           variant="ghost"
@@ -157,7 +152,7 @@ export function MapDrawer({
     <div className="flex flex-col overflow-hidden flex-1">
       <div className="flex items-center gap-2 p-3 shrink-0">
         <div className="flex-1">
-          <Search value={searchValue} onValueChange={setSearchValue} />
+          <Search value={searchValue} onValueChange={onSearchChange} />
         </div>
         <Button
           variant="ghost"
@@ -175,8 +170,8 @@ export function MapDrawer({
       </div>
       <div className="flex items-center justify-between px-3 py-2 shrink-0">
         <span className="text-xs text-muted-foreground">
-          {searchedResults.length} result
-          {searchedResults.length !== 1 ? "s" : ""}
+          {searchedMediaPoints.length} result
+          {searchedMediaPoints.length !== 1 ? "s" : ""}
         </span>
         {hasActiveFilters && (
           <Button
@@ -191,14 +186,14 @@ export function MapDrawer({
         )}
       </div>
       <div className="overflow-y-auto flex-1 styled-scrollbar">
-        {searchedResults.map((media) => (
+        {searchedMediaPoints.map((media) => (
           <ResultCard
             key={media.id}
             media={media}
             isSelected={media.id === mediaPointId}
           />
         ))}
-        {searchedResults.length === 0 && (
+        {searchedMediaPoints.length === 0 && (
           <div className="p-4 text-sm text-muted-foreground text-center">
             No results found.
           </div>

--- a/components/map.tsx
+++ b/components/map.tsx
@@ -8,7 +8,6 @@ import { MapFilters, MediaLocation } from "@/lib/airtable/types";
 import { addQueryParameter, hasActiveFilters } from "@/lib/utils";
 import {
   addDataLayer,
-  applySelectionStyling,
   setupKeyboardNav,
   DEFAULT_BOUNDS,
   DEFAULT_ZOOM,
@@ -84,46 +83,25 @@ export function Map({ data, bounds, filters, styleUrl, onMapReady }: MapProps) {
     map.current.setStyle(styleUrl);
     map.current.once("style.load", () => {
       if (map.current) {
-        addDataLayer(map.current, data);
-        applySelectionStyling(map.current, data, selectedMediaPoint);
+        addDataLayer(map.current, data, selectedMediaPoint);
       }
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [styleUrl, isMapLoaded]);
 
-  // Sync the GeoJSON data layer whenever the dataset changes (e.g. filters
-  // applied). Removes the layer and source on cleanup to avoid duplicates.
+  // Sync the GeoJSON data layer with selection included in a single
+  // setData() call to avoid intermediate frames with missing styling.
   useEffect(() => {
     if (!map.current || !isMapLoaded) return;
 
-    addDataLayer(map.current, data);
-
-    // Cleanup
-    return () => {
-      if (map.current) {
-        if (map.current.getLayer("media-points-layer")) {
-          map.current.removeLayer("media-points-layer");
-        }
-        if (map.current.getSource("media-points")) {
-          map.current.removeSource("media-points");
-        }
-      }
-    };
-  }, [isMapLoaded, data]);
-
-  // Fly to the selected media point and highlight it. Resets styling
-  // back to default when no point is selected.
-  useEffect(() => {
-    if (!map.current || !isMapLoaded) return;
+    addDataLayer(map.current, data, selectedMediaPoint);
 
     if (selectedMediaPoint) {
       map.current.flyTo({
         center: [selectedMediaPoint.longitude, selectedMediaPoint.latitude],
       });
     }
-
-    applySelectionStyling(map.current, data, selectedMediaPoint);
-  }, [selectedMediaPoint, isMapLoaded, data]);
+  }, [isMapLoaded, data, selectedMediaPoint]);
 
   // Auto-select a random point on first load so the UI isn't empty.
   // Skipped if a point is already selected or filters are active.

--- a/lib/map-utils.ts
+++ b/lib/map-utils.ts
@@ -99,11 +99,20 @@ export function setupKeyboardNav(
 /**
  * Add or update the media-points GeoJSON source and circle layer.
  *
- * If the source already exists, its data is replaced in-place.
+ * If the source already exists, its data is replaced in-place via setData().
+ * The optional `selected` parameter sets a `selected` property on the
+ * matching feature so that paint expressions can highlight it. Including
+ * selection in the same setData() call avoids an intermediate render frame
+ * where points flash with default (black) styling.
+ *
  * Click and hover interactions are registered on the layer so that
  * selecting a point updates the URL and the cursor changes on hover.
  */
-export function addDataLayer(mapInstance: mapboxgl.Map, data: MediaLocation[]) {
+export function addDataLayer(
+  mapInstance: mapboxgl.Map,
+  data: MediaLocation[],
+  selected?: MediaLocation | null
+) {
   const geojson = {
     type: "FeatureCollection",
     features: data.map((point) => ({
@@ -114,6 +123,7 @@ export function addDataLayer(mapInstance: mapboxgl.Map, data: MediaLocation[]) {
       },
       properties: {
         ...point,
+        selected: point.id === selected?.id,
       },
     })),
   };
@@ -169,37 +179,4 @@ export function addDataLayer(mapInstance: mapboxgl.Map, data: MediaLocation[]) {
       mapInstance.getCanvas().style.cursor = "";
     });
   }
-}
-
-/**
- * Highlight the selected media point on the map.
- *
- * Updates the GeoJSON `selected` property so that circle-sort-key
- * pushes the selected point above all others, and paint expressions
- * apply the highlight styling.
- */
-export function applySelectionStyling(
-  mapInstance: mapboxgl.Map,
-  data: MediaLocation[],
-  selected: MediaLocation | null | undefined
-) {
-  const source = mapInstance.getSource("media-points") as GeoJSONSource;
-  if (!source) return;
-
-  const geojson = {
-    type: "FeatureCollection" as const,
-    features: data.map((point) => ({
-      type: "Feature" as const,
-      geometry: {
-        type: "Point" as const,
-        coordinates: [point.longitude, point.latitude],
-      },
-      properties: {
-        ...point,
-        selected: point.id === selected?.id,
-      },
-    })),
-  };
-
-  source.setData(geojson);
 }


### PR DESCRIPTION
- Lift search state from MapDrawer to MapContainer so both the results list and map markers update as the user types.
- Merge addDataLayer and applySelectionStyling into a single setData() call to eliminate the intermediate frame that caused points to flash black.